### PR TITLE
Update test-secured-api.md

### DIFF
--- a/lab_11_-_securing_apis_with_oauth2/test-secured-api.md
+++ b/lab_11_-_securing_apis_with_oauth2/test-secured-api.md
@@ -21,6 +21,7 @@ Now that RH-SSO is ready and the API has been secured in 3scale, you will test i
 | Parameter | Value |
 | --- | --- |
 | **Token Name** | 3scale-OIDC |
+| **Callback URL** | https://www.getpostman.com/oauth2/callback |
 | **Auth URL** | http://sso-unsecured.{{ book.suffix }}/auth/realms/3scaleRealm/protocol/openid-connect/auth |
 | **Access Token URL** | http://sso-unsecured.{{ book.suffix }}/auth/realms/3scaleRealm/protocol/openid-connect/token |
 | **Client ID** | &lt;Paste the Client ID from the Application created in 3scale&gt; |


### PR DESCRIPTION
Postman as chrome extension is no longer available. When using the Postman application the callback URL should be set.